### PR TITLE
Work with relative instead of absolute timestamps

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -5,8 +5,8 @@ AxivityNumUnpack <- function(pack) {
     .Call(`_GGIRread_AxivityNumUnpack`, pack)
 }
 
-GENEActivReader <- function(filename, start = 0L, end = 0L, progress_bar = FALSE, tzone = 0L) {
-    .Call(`_GGIRread_GENEActivReader`, filename, start, end, progress_bar, tzone)
+GENEActivReader <- function(filename, start = 0L, end = 0L, progress_bar = FALSE) {
+    .Call(`_GGIRread_GENEActivReader`, filename, start, end, progress_bar)
 }
 
 resample <- function(raw, rawTime, time, stop, type = 1L) {

--- a/R/readGENEActiv.R
+++ b/R/readGENEActiv.R
@@ -1,7 +1,6 @@
 readGENEActiv = function(filename, start = 0, end = 0,
                               progress_bar = FALSE, desiredtz = "") {
   
- 
   # Extract information from the fileheader
   suppressWarnings({fh = readLines(filename, 69)})
   
@@ -13,22 +12,16 @@ readGENEActiv = function(filename, start = 0, end = 0,
                   x = fh[grep(pattern = "Lux", x = fh)[1]]))
   Volts = as.numeric(gsub(pattern = "Volts:", replacement = "",
              x = fh[grep(pattern = "Volts", x = fh)[1]]))
-  starttime = gsub(pattern = "Start Time::", replacement = "",
+  starttime = gsub(pattern = "Start Time:", replacement = "",
                   x = fh[grep(pattern = "Start Time", x = fh)[1]])
   
   tzone = gsub(pattern = "Time Zone:", replacement = "",
                x = fh[grep(pattern = "Time Zone", x = fh)[1]])
   tzone = as.numeric(unlist(strsplit(tzone, "[:]| "))[2]) * 3600
   
-  cat(paste0("\nreadGENEActiv tz_offsetz: ",tzone, "\n"))
-  
-  
-  
   rawdata = GENEActivReader(filename = filename,
                             start = start, end = end, 
-                            progress_bar = progress_bar, tzone = tzone)
-  
-  # rawdata$time  = rawdata$time + tz_offset * 1000 # no needed anymore to correct data
+                            progress_bar = progress_bar)
   
   header = list(serial_number = SN,
                       firmware = firmware,
@@ -36,13 +29,11 @@ readGENEActiv = function(filename, start = 0, end = 0,
                       ReadOK = rawdata$info$ReadOK,
                       SampleRate = rawdata$info$SampleRate,
                       ReadErrors = rawdata$info$ReadErrors,
-                      numBlocksTotal = rawdata$info$numBlocksTotal)
+                      numBlocksTotal = rawdata$info$numBlocksTotal,
+                      StarTime = starttime)
   rawdata$time = rawdata$time / 1000
-  if (rawdata$time[1] < 0) {
-    cat("\nCorrecting timestamps by falling back on timestamps from the file header")
-    rawdata$time = rawdata$time + abs(rawdata$time[1]) + as.numeric(as.POSIXlt(x = starttime, tz = desiredtz, format = "%Y-%m-%d %H:%M:%OS"))
-  }
-  
+  starttime_num = as.numeric(as.POSIXlt(x = starttime, tz = desiredtz, format = "%Y-%m-%d %H:%M:%OS")) + tzone + 5
+  rawdata$time = rawdata$time + abs(rawdata$time[1]) + starttime_num
   return(invisible(list(
     header = header,
     data = data.frame(time = rawdata$time, 

--- a/man/GENEActivReader.Rd
+++ b/man/GENEActivReader.Rd
@@ -8,7 +8,7 @@
   (Unilever Discover, UK). For reading GENEActive binary data, see package GENEAread.
 }
 \usage{
-  GENEActivReader(filename, start = 0L, end = 0L, progress_bar = FALSE, tzone = 0)
+  GENEActivReader(filename, start = 0L, end = 0L, progress_bar = FALSE)
 }
 \arguments{
   \item{filename}{
@@ -22,9 +22,6 @@
   }
   \item{progress_bar}{
     Boolean
-  }
-  \item{tzone}{
-    Numeric, timezone in seconds to interpret the timestamps in. For example, 3600 for GMT+01:00
   }
 }
 \details{

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -22,8 +22,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // GENEActivReader
-Rcpp::List GENEActivReader(std::string filename, std::size_t start, std::size_t end, bool progress_bar, int tzone);
-RcppExport SEXP _GGIRread_GENEActivReader(SEXP filenameSEXP, SEXP startSEXP, SEXP endSEXP, SEXP progress_barSEXP, SEXP tzoneSEXP) {
+Rcpp::List GENEActivReader(std::string filename, std::size_t start, std::size_t end, bool progress_bar);
+RcppExport SEXP _GGIRread_GENEActivReader(SEXP filenameSEXP, SEXP startSEXP, SEXP endSEXP, SEXP progress_barSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -31,8 +31,7 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< std::size_t >::type start(startSEXP);
     Rcpp::traits::input_parameter< std::size_t >::type end(endSEXP);
     Rcpp::traits::input_parameter< bool >::type progress_bar(progress_barSEXP);
-    Rcpp::traits::input_parameter< int >::type tzone(tzoneSEXP);
-    rcpp_result_gen = Rcpp::wrap(GENEActivReader(filename, start, end, progress_bar, tzone));
+    rcpp_result_gen = Rcpp::wrap(GENEActivReader(filename, start, end, progress_bar));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -54,7 +53,7 @@ END_RCPP
 
 static const R_CallMethodDef CallEntries[] = {
     {"_GGIRread_AxivityNumUnpack", (DL_FUNC) &_GGIRread_AxivityNumUnpack, 1},
-    {"_GGIRread_GENEActivReader", (DL_FUNC) &_GGIRread_GENEActivReader, 5},
+    {"_GGIRread_GENEActivReader", (DL_FUNC) &_GGIRread_GENEActivReader, 4},
     {"_GGIRread_resample", (DL_FUNC) &_GGIRread_resample, 5},
     {NULL, NULL, 0}
 };

--- a/tests/testthat/test_readGENEActiv.R
+++ b/tests/testthat/test_readGENEActiv.R
@@ -3,7 +3,7 @@ context("GENEActivReader")
 test_that("GENEActivReader reads data from file correctly", {
   skip_on_cran()
   binfile  = system.file("testfiles/GENEActiv_testfile.bin", package = "GGIRread")[1]
-  GENEActiv = GENEActivReader(filename = binfile, start = 1, end = 1, tzone = 3600)
+  GENEActiv = GENEActivReader(filename = binfile, start = 1, end = 1)
   
   expect_equal(GENEActiv$info$ReadOK, 1)
   expect_equal(GENEActiv$info$ReadErrors, 0)
@@ -16,10 +16,9 @@ test_that("GENEActivReader reads data from file correctly", {
   expect_equal(length(GENEActiv$T), 300)
   expect_equal(GENEActiv$T[1], 21.5)
   expect_equal(GENEActiv$z[300], -0.80836403369903564453, tolerance = 15)
-  expect_equal(GENEActiv$time[1], 1369908774500)
-  cat(paste0("\nUnit test, 2nd timestamp GENEActiv$time: ", GENEActiv$time[1], "\n"))
+  expect_equal(GENEActiv$time[1], 500)
   
-  GBR = readGENEActiv(filename = binfile, start = 1, end = 1)
+  GBR = readGENEActiv(filename = binfile, start = 1, end = 1, desiredtz = "Europe/London")
   expect_equal(GBR$header$ReadOK, 1)
   expect_equal(GBR$header$ReadErrors, 0)
   expect_equal(GBR$header$SampleRate, 85.7)
@@ -33,7 +32,6 @@ test_that("GENEActivReader reads data from file correctly", {
   expect_equal(GBR$data$temperature[1], 21.5)
   expect_equal(GBR$data$light[2], 2.666667, tolerance = 4)
   expect_equal(GBR$data$z[300], -0.80836403369903564453, tolerance = 15)
-  cat(paste0("\nUnit test, 2nd timestamp GBR$data$time: ", GBR$data$time[2], "\n"))
   expect_equal(GBR$data$time[1], 1369908774.500) # output is now expressed in seconds rather than milliseconds
 
 })


### PR DESCRIPTION
This attempts to resolve the WindowsOS issues with PR #3
Instead cpp we only work with time relative to start of recording. The conversion to Unix time now happens in R.