### PR TITLE
Speeding up readAxivity

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: GGIRread
 Type: Package
 Title: Wearable Accelerometer Data File Readers
-Version: 0.2.6
-Date: 2022-12-05
+Version: 0.2.7
+Date: 2022-05-12
 Authors@R: c(person("Vincent T","van Hees",role=c("aut","cre"),
                   email="v.vanhees@accelting.com"),
              person(given = "Patrick",family = "Bos",

--- a/R/readAxivity.R
+++ b/R/readAxivity.R
@@ -412,12 +412,13 @@ readAxivity = function(filename, start = 0, end = 0, progressBar = FALSE, desire
     # Save start and length of the previous block
     prevStart = prevRaw$start
     prevLength = prevRaw$length
+    struc = raw$struc
     # Check are previous data block necessary
     if (raw$start < start) {
       prevRaw = raw
       next
     }
-    struc = raw$struc
+    
     # Create array of times
     time = seq(prevStart, raw$start, length.out = prevLength + 1)
     

--- a/R/readAxivity.R
+++ b/R/readAxivity.R
@@ -203,8 +203,8 @@ readAxivity = function(filename, start = 0, end = 0, progressBar = FALSE, desire
         temp = 482 -  4 * (Naxes/3) * blockLength
       } else {
         # Read unpacked data
-        xyz = readBin(fid, integer(), size = 2, n = blockLength * Naxes) #*3
-        data = matrix(xyz, ncol = Naxes, byrow = T, dimnames = FALSE) #3
+        xyz = readBin(fid, integer(), size = 2, n = blockLength * Naxes)
+        data = matrix(xyz, ncol = Naxes, byrow = T)
         # Calculate number of bytes to skip
         temp = 482 - (2 * Naxes * blockLength)
       }

--- a/R/readAxivity.R
+++ b/R/readAxivity.R
@@ -412,7 +412,6 @@ readAxivity = function(filename, start = 0, end = 0, progressBar = FALSE, desire
     if (i >= blockSkip) { # start of recording
       raw = readDataBlock(fid, header_accrange = header$accrange, struc = struc,
                           parameters = prevRaw$parameters)
-      i = i + 1
     } else {
       # skip blocks
       seek(fid, 512 * blockSkip, origin = 'current')
@@ -479,6 +478,7 @@ readAxivity = function(filename, start = 0, end = 0, progressBar = FALSE, desire
     if (pos > nr) {
       break
     }
+    i = i + 1
   }
   #############################################################################
   # Process the last block of data if necessary

--- a/R/readAxivity.R
+++ b/R/readAxivity.R
@@ -404,14 +404,11 @@ readAxivity = function(filename, start = 0, end = 0, progressBar = FALSE, desire
   }
   rawPos = 1
   
-  # Pseudo code for possible revision:
-  # - Extract sector/block size in bytes => see c-link https://github.com/digitalinteraction/openmovement/blob/d8678127c8331196072215a2f1a3dfe7fa595915/Software/AX3/cwa-convert/c/main.c#L278
-  # - Op basis van block_start do seek() to skip
-  # - Run code as shown below
   for (i in 2:numDBlocks) {
     timeSkip = start - prevRaw$start
     blockDur = prevRaw$length / prevRaw$frequency
     blockSkip = floor(timeSkip/blockDur) - 1
+    
     if (i >= blockSkip) { # start of recording
       raw = readDataBlock(fid, header_accrange = header$accrange, struc = struc,
                           parameters = prevRaw$parameters)
@@ -481,8 +478,7 @@ readAxivity = function(filename, start = 0, end = 0, progressBar = FALSE, desire
   }
   #############################################################################
   # Process the last block of data if necessary
-  if (pos <= nr) { # & ignorelastblock == FALSE) {
-    # print("last block of data")
+  if (pos <= nr & exists("prevStart") & exists("prevLength")) {
     # Calculate pseudo time for the "next" block
     newTimes = (prevRaw$start - prevStart) / prevLength * prevRaw$length + prevRaw$start
     prevLength = prevRaw$length

--- a/R/readAxivity.R
+++ b/R/readAxivity.R
@@ -405,17 +405,17 @@ readAxivity = function(filename, start = 0, end = 0, progressBar = FALSE, desire
   rawPos = 1
   i = 2
   while (i <= numDBlocks) {
-    timeSkip = start - prevRaw$start
+    time2Skip = start - prevRaw$start
     blockDur = prevRaw$length / prevRaw$frequency
-    blockSkip = floor(timeSkip/blockDur) - 1
+    Nblocks2Skip = floor(time2Skip/blockDur) - 1
     
-    if (i >= blockSkip) { # start of recording
+    if (i >= Nblocks2Skip) { # start of recording
       raw = readDataBlock(fid, header_accrange = header$accrange, struc = struc,
                           parameters = prevRaw$parameters)
     } else {
       # skip blocks
-      seek(fid, 512 * blockSkip, origin = 'current')
-      i = i + blockSkip
+      seek(fid, 512 * Nblocks2Skip, origin = 'current')
+      i = i + Nblocks2Skip
       next
     }
     if (is.null(raw)) {

--- a/R/readAxivity.R
+++ b/R/readAxivity.R
@@ -403,8 +403,8 @@ readAxivity = function(filename, start = 0, end = 0, progressBar = FALSE, desire
     rawAccel = matrix(0, nrow = 300 * Npages, ncol = 6)
   }
   rawPos = 1
-  
-  for (i in 2:numDBlocks) {
+  i = 2
+  while (i <= numDBlocks) {
     timeSkip = start - prevRaw$start
     blockDur = prevRaw$length / prevRaw$frequency
     blockSkip = floor(timeSkip/blockDur) - 1
@@ -412,8 +412,11 @@ readAxivity = function(filename, start = 0, end = 0, progressBar = FALSE, desire
     if (i >= blockSkip) { # start of recording
       raw = readDataBlock(fid, header_accrange = header$accrange, struc = struc,
                           parameters = prevRaw$parameters)
+      i = i + 1
     } else {
-      seek(fid, 512, origin = 'current') # skip block
+      # skip blocks
+      seek(fid, 512 * blockSkip, origin = 'current')
+      i = i + blockSkip
       next
     }
     if (is.null(raw)) {
@@ -426,6 +429,7 @@ readAxivity = function(filename, start = 0, end = 0, progressBar = FALSE, desire
     # Check are previous data block necessary
     if (raw$start < start) {
       prevRaw = raw
+      i = i + 1
       next
     }
     # Create array of times

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -1,6 +1,11 @@
 \name{NEWS}
 \title{News for Package \pkg{GGIRread}}
 \newcommand{\cpkg}{\href{http://CRAN.R-project.org/package=#1}{\pkg{#1}}}
+\section{Changes in version 0.2.7 (release date:12-05-2022)}{
+    \itemize{
+      \item Speeding up readAxivity function by approximately 65 percent.
+    }
+}
 \section{Changes in version 0.2.6 (release date:05-12-2022)}{
     \itemize{
       \item New CRAN release, only minor improvements to syntax

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -3,7 +3,7 @@
 \newcommand{\cpkg}{\href{http://CRAN.R-project.org/package=#1}{\pkg{#1}}}
 \section{Changes in version 0.2.7 (release date:12-05-2022)}{
     \itemize{
-      \item Speeding up readAxivity function by approximately 65 percent.
+      \item Speeding up readAxivity function by approximately 75 percent.
     }
 }
 \section{Changes in version 0.2.6 (release date:05-12-2022)}{


### PR DESCRIPTION
This PR speeds up function readAxivity for reading .cwa files (discussed in #14). 
The new speed-up is primarily gained by how the code searches for data chunks (batches) later on in the recording.

## Processing time improvements for running GGIR 2.9.1 - part 1 on:

### My own AX3 test file (284 MB):
- OLD: 400 seconds
- NEW: 102 seconds
- Difference: -75%

### My own AX6 test file (164 MB):
- OLD: 229 seconds
- NEW: 55 seconds
- Difference: -76%

### UK Biobank AX3 test file (265 MB):
- OLD: 350 seconds
- NEW: 92 seconds
- Difference: -74%

@jhmigueles Would you mind testing this on some of your own data to confirm these findings?

Thanks @egpbos for the brainstorm session this morning, as you can see it helped a lot.