### PR TITLE
Issue29 axivity variable sf

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: GGIRread
 Type: Package
 Title: Wearable Accelerometer Data File Readers
-Version: 0.2.7
-Date: 2023-05-17
+Version: 0.2.8
+Date: 2023-05-24
 Authors@R: c(person("Vincent T","van Hees",role=c("aut","cre"),
                   email="v.vanhees@accelting.com"),
              person(given = "Patrick",family = "Bos",

--- a/R/readAxivity.R
+++ b/R/readAxivity.R
@@ -418,6 +418,7 @@ readAxivity = function(filename, start = 0, end = 0, progressBar = FALSE, desire
     blockDur = prevRaw$length / prevRaw$frequency
 
     Nblocks2Skip = floor((time2Skip/blockDur) * samplingFrac) 
+    
     if (Nblocks2Skip <= 0 | skippedLast == TRUE) { # start of recording
       skippedLast = FALSE
       raw = readDataBlock(fid, header_accrange = header$accrange, struc = struc,
@@ -453,17 +454,17 @@ readAxivity = function(filename, start = 0, end = 0, progressBar = FALSE, desire
       struc = struc_backup
       prevRaw = prevRaw_backup
       if (samplingFrac == 1) {
-        samplingFrac = 0.2
+        samplingFrac = 0.5
       } else {
         stop(paste0("GGIRread is having difficulty to read .cwa file.",
-                    " Please report to GGIRread package maintainers."))
+                    " It is seeing less than 50% of the expacted data points.",
+                    " Please report to GGIRread package maintainers."), call. = FALSE)
       }
       next
     }
     segmentFound = TRUE
     # Create array of times
     time = seq(prevStart, raw$start, length.out = prevLength + 1)
-    
     # fill vector rawTime and matrix rawAccel for resampling
     if (rawPos == 1) {
       rawAccel[1,] = (prevRaw$data[1,])

--- a/R/readAxivity.R
+++ b/R/readAxivity.R
@@ -200,7 +200,7 @@ readAxivity = function(filename, start = 0, end = 0, progressBar = FALSE, desire
         # Read 4 byte for three measurements
         packedData = readBin(fid, integer(), size = 4, n = blockLength)
         # Unpack data
-        data = GGIRread:::AxivityNumUnpack(packedData) #GGIRread:::
+        data = AxivityNumUnpack(packedData) #GGIRread:::
         # data2 = numUnpack2(packedData)
         # Calculate number of bytes to skip
         temp = 482 -  4 * (Naxes/3) * blockLength

--- a/R/readAxivity.R
+++ b/R/readAxivity.R
@@ -409,7 +409,7 @@ readAxivity = function(filename, start = 0, end = 0, progressBar = FALSE, desire
   i = 2
   segmentFound = FALSE
   skippedLast = FALSE
-  samplingFrac = 1     # if less than 1 we assume that sampling rate has a long term
+  samplingFrac = 0.95     # if less than 1 we assume that sampling rate has a long term
   # downward drift no larger than fraction 1 - samplingFrac
   prevRaw_backup = prevRaw
   struc_backup = struc
@@ -453,12 +453,12 @@ readAxivity = function(filename, start = 0, end = 0, progressBar = FALSE, desire
       seek(fid, 512 + 1024, origin = 'start') # skip header and one block of data
       struc = struc_backup
       prevRaw = prevRaw_backup
-      if (samplingFrac == 1) {
+      if (samplingFrac == 0.95) {
         samplingFrac = 0.5
       } else {
         stop(paste0("GGIRread is having difficulty to read .cwa file.",
                     " It is seeing less than 50% of the expacted data points.",
-                    " Please report to GGIRread package maintainers."), call. = FALSE)
+                    " Please report to GGIRread package maintainers and Axivity Ltd."), call. = FALSE)
       }
       next
     }

--- a/R/readAxivity.R
+++ b/R/readAxivity.R
@@ -143,8 +143,10 @@ readAxivity = function(filename, start = 0, end = 0, progressBar = FALSE, desire
     temp = readBin(fid, integer(), size = 2) # timestampOffset
     if (is.null(parameters)) {
       # number of observations in block U16 in offset 28
-      blockLength = readBin(fid, integer(), size = 2) # blockLength is expected to be 40 for AX6, 80 or 120 for AX3
-      print(blockLength)
+      # blockLength is expected to be 40 for AX6, 80 or 120 for AX3
+      # Note that of AX6 is configured to only collect accelerometer data
+      # this will look as if it is a AX3
+      blockLength = readBin(fid, integer(), size = 2) 
       accelScaleCode = bitwShiftR(offset18, 13)
       accelScale = 1 / (2^(8 + accelScaleCode)) # abs removed
       Naxes = as.integer(substr(temp_raw,1,1))
@@ -198,7 +200,7 @@ readAxivity = function(filename, start = 0, end = 0, progressBar = FALSE, desire
         # Read 4 byte for three measurements
         packedData = readBin(fid, integer(), size = 4, n = blockLength)
         # Unpack data
-        data = AxivityNumUnpack(packedData) #GGIRread:::
+        data = GGIRread:::AxivityNumUnpack(packedData) #GGIRread:::
         # data2 = numUnpack2(packedData)
         # Calculate number of bytes to skip
         temp = 482 -  4 * (Naxes/3) * blockLength

--- a/R/readAxivity.R
+++ b/R/readAxivity.R
@@ -485,7 +485,7 @@ readAxivity = function(filename, start = 0, end = 0, progressBar = FALSE, desire
     rawLast = prevLength + rawPos - 1
     rawTime[rawPos:rawLast] = time[1:prevLength]
     rawAccel[rawPos:rawLast,] = as.matrix(prevRaw$data)
-    lastTime = time[prevLength]
+    # lastTime = time[prevLength]
     ###########################################################################
     # resampling of measurements
     last = pos + 200;
@@ -539,7 +539,7 @@ readAxivity = function(filename, start = 0, end = 0, progressBar = FALSE, desire
     rawLast = prevLength + rawPos - 1
     rawTime[rawPos:rawLast] = time[1:prevLength]
     rawAccel[rawPos:rawLast,] = as.matrix(prevRaw$data)
-    lastTime = time[prevLength]
+    # lastTime = time[prevLength]
     ###########################################################################
     # resampling of measurements
     last = pos + 200;

--- a/R/readAxivity.R
+++ b/R/readAxivity.R
@@ -449,7 +449,7 @@ readAxivity = function(filename, start = 0, end = 0, progressBar = FALSE, desire
       # Go back to beginning of file and use lower samplingFrac
       i = 2
       seek(fid,0)
-      seek(fid, (512 * i) + 1024, origin = 'start')
+      seek(fid, 512 + 1024, origin = 'start') # skip header and one block of data
       struc = struc_backup
       prevRaw = prevRaw_backup
       if (samplingFrac == 1) {

--- a/R/readAxivity.R
+++ b/R/readAxivity.R
@@ -409,8 +409,7 @@ readAxivity = function(filename, start = 0, end = 0, progressBar = FALSE, desire
   i = 2
   segmentFound = FALSE
   skippedLast = FALSE
-  samplingFrac = 0.95     # if less than 1 we assume that sampling rate has a long term
-  # downward drift no larger than fraction 1 - samplingFrac
+  samplingFrac = 1 # first assume that sampling rate is 95% of expected value or higher
   prevRaw_backup = prevRaw
   struc_backup = struc
   while (i <= numDBlocks) {
@@ -418,7 +417,6 @@ readAxivity = function(filename, start = 0, end = 0, progressBar = FALSE, desire
     blockDur = prevRaw$length / prevRaw$frequency
 
     Nblocks2Skip = floor((time2Skip/blockDur) * samplingFrac) 
-    
     if (Nblocks2Skip <= 0 | skippedLast == TRUE) { # start of recording
       skippedLast = FALSE
       raw = readDataBlock(fid, header_accrange = header$accrange, struc = struc,
@@ -449,14 +447,14 @@ readAxivity = function(filename, start = 0, end = 0, progressBar = FALSE, desire
       # Oops start was missed, because sampling rate was lower than expected
       # Go back to beginning of file and use lower samplingFrac
       i = 2
-      seek(fid,0)
+      seek(fid, 0)
       seek(fid, 512 + 1024, origin = 'start') # skip header and one block of data
       struc = struc_backup
       prevRaw = prevRaw_backup
-      if (samplingFrac == 0.95) {
+      if (samplingFrac == 1) {
         samplingFrac = 0.5
       } else {
-        stop(paste0("GGIRread is having difficulty to read .cwa file.",
+        stop(paste0("GGIRread is having difficulty to read this .cwa file.",
                     " It is seeing less than 50% of the expacted data points.",
                     " Please report to GGIRread package maintainers and Axivity Ltd."), call. = FALSE)
       }

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -1,6 +1,11 @@
 \name{NEWS}
 \title{News for Package \pkg{GGIRread}}
 \newcommand{\cpkg}{\href{http://CRAN.R-project.org/package=#1}{\pkg{#1}}}
+\section{Changes in version 0.2.8 (release date:24-05-2023)}{
+    \itemize{
+      \item Major bug fix introduced in 0.2.7 release affecting readAxivity
+    }
+}
 \section{Changes in version 0.2.7 (release date:17-05-2023)}{
     \itemize{
       \item Fixes bug in LUX extraction for GENEActiv .bin data (#27)

--- a/man/GGIRread-package.Rd
+++ b/man/GGIRread-package.Rd
@@ -14,8 +14,8 @@
   \tabular{ll}{
   Package: \tab GGIRread\cr
   Type: \tab Package\cr
-  Version: \tab 0.2.7\cr
-  Date: \tab 2023-05-17\cr
+  Version: \tab 0.2.8\cr
+  Date: \tab 2023-05-24\cr
   License: \tab LGPL (>= 2.0, < 3)\cr
   }
 }

--- a/src/resample.cpp
+++ b/src/resample.cpp
@@ -25,6 +25,9 @@ NumericMatrix resample(NumericMatrix raw, NumericVector rawTime,
         for (int p = 0; p < last; p++) { //p is number of point to calculate
           for (; rawTime(pos) < time(p); pos++);
           u = (time(p) - rawTime(pos - 1)) / (rawTime(pos) - rawTime(pos - 1));
+          if (u < 0 || u > 1) {
+            u = 0;
+          }
           res(p, j) = u * (raw(pos ,j) - raw(pos - 1, j)) + raw(pos-1 ,j);
         }  
       }
@@ -36,6 +39,9 @@ NumericMatrix resample(NumericMatrix raw, NumericVector rawTime,
         for (int p = 0; p < last; p++) { //p is number of point to calculate
           for (; rawTime(pos) < time(p); pos++);
           u = (time(p) - rawTime(pos - 1)) / (rawTime(pos) - rawTime(pos - 1));
+          if (u < 0 || u > 1) {
+            u = 0;
+          }
           res(p, j) = std::ceil(u-0.5f) * (raw(pos ,j) - raw(pos - 1, j)) + raw(pos-1 ,j);
         }  
       }


### PR DESCRIPTION
This PR fixes #29 

As of release 0.2.7 (last week) the code assumed a steady number of samples per block based on sampling rate and file type.
This, I now realise, is not a safe assumption for Axivity as it can have a variable sampling rate.

As a result too much data is being skipped when searching for the next block when sampling rate is lower than expected.
In the opposite situation when the sampling rate is higher than expected it is not a problem because the code will keep iterating over the blocks until it has found the correct timestamp.

Based on test data I see the error can be around 0.6%. So, I updated the code with an extra safety margin by only skipping 97% of the anticipated data to be skipped. So, for now I assume that the error in sampling rate never gets more than 3% accumulated over time.

UPDATE: I have now revised this to follow the logic:
- Code first tries fraction 0.97 (if start of data segment to read is at 100, it will skip the first 97 and start reading block by block from there)
- If that fails because somehow when we arrive at 97 we see that we are already beyond timestamp 100 then it goes back to beginning of the file and tries fraction = fraction - 0.1
- The previous step is repeated until fraction is less than 0.2 after which it goes the beginning of the file and uses the old and slow approach and gives a warning to the user that something may be wrong with the file.
