### PR TITLE
use last valid value as imputation value, not last value from the block being imputed

### DIFF
--- a/R/readAxivity.R
+++ b/R/readAxivity.R
@@ -534,9 +534,9 @@ readAxivity = function(filename, start = 0, end = 0, progressBar = FALSE, desire
       doQClog = TRUE
       impute = TRUE
       
-      # Prepare imputation with last recorded value from previous block
+      # Prepare imputation with last recorded value, from the last non-faulty block,
       # normalized to vector 1 g
-      imputedValues = prevRaw$data[nrow(prevRaw$data), 1:3]
+      imputedValues = rawAccel[1, 1:3]
       VectorG = sqrt(sum(imputedValues^2))
       if (VectorG > 0.8 & VectorG < 1.2) {
         # only trust vector as proxy for orientation if it is between 0.8 and 1.2


### PR DESCRIPTION
@vincentvanhees sorry, I should have noticed this yesterday. Currently a faulty block is being imputed with the last value from that same block. Is that correct? Should it maybe be imputed with the last valid value, which at that point is stored in rawAccel[1]?