### PR TITLE
impute only as many values as needed, not 201

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: GGIRread
 Type: Package
 Title: Wearable Accelerometer Data File Readers
 Version: 0.3.1
-Date: 2023-08-07
+Date: 2023-08-30
 Authors@R: c(person("Vincent T","van Hees",role=c("aut","cre"),
                   email="v.vanhees@accelting.com"),
              person(given = "Patrick",family = "Bos",

--- a/R/readAxivity.R
+++ b/R/readAxivity.R
@@ -588,8 +588,11 @@ readAxivity = function(filename, start = 0, end = 0, progressBar = FALSE, desire
         stop(paste0("\nreadAxivity encountered a time gap in the file of ",
                     round((last - pos) / (3600 * 24) / prevRaw$frequency, digits = 2), " days"))
       }
-      
-      tmp = matrix(0, last - pos + 1, prevRaw$parameters$Naxes)
+
+      # Figure out the number of points to impute, numImp.
+      # numImp should be such that timeRes[numImp + pos + 1] is the last point in timeRes[] < rawTime[rawLast]
+      numImp = length(which(timeRes[pos:last]<rawTime[rawLast]))
+      tmp = matrix(0, numImp, prevRaw$parameters$Naxes)
       for (axi in 1:3) tmp[, axi] = imputedValues[axi]
     }
     

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -1,6 +1,14 @@
 \name{NEWS}
 \title{News for Package \pkg{GGIRread}}
 \newcommand{\cpkg}{\href{http://CRAN.R-project.org/package=#1}{\pkg{#1}}}
+\section{Changes in version 0.3.1 (release date: 30-08-2023)}{
+    \itemize{
+      \item No iterate through cwa files using native cwea blocks insted of 300
+      sample pages.
+      \item Deprecated option to iterate based on timestamps.
+      \item Now properly accounts for unexpected high sampling rate for the imputation.
+    }
+}
 \section{Changes in version 0.3.0 (release date: 07-08-2023)}{
     \itemize{
       \item Improved imputation of faulty blocks readAxivity

--- a/man/GGIRread-package.Rd
+++ b/man/GGIRread-package.Rd
@@ -15,7 +15,7 @@
   Package: \tab GGIRread\cr
   Type: \tab Package\cr
   Version: \tab 0.3.1\cr
-  Date: \tab 2023-08-07\cr
+  Date: \tab 2023-08-30\cr
   License: \tab LGPL (>= 2.0, < 3)\cr
   }
 }


### PR DESCRIPTION
We were always imputing 201 values instead of whatever number was needed.

We have a couple of test files where this had a particularly bad effect -- there was an odd chunk with abnormally high frequency (twice the expected frequency), and when we imputed it with 200 values instead of ~50 that we should have, we went completely past the next chunk, so that next chunk then ended up with a negative frequency and got imputed as well, and that domino effect continued for over 1000 chunks.