### PR TITLE
Minor correction of timestamp handling code in readGENEActiv

### DIFF
--- a/R/readGENEActiv.R
+++ b/R/readGENEActiv.R
@@ -65,8 +65,6 @@ readGENEActiv = function(filename, start = 0, end = 0, progress_bar = FALSE,
   } else {
     starttime_posix = as.POSIXlt(starttime, tz = configtz,
                                  format = "%Y-%m-%d %H:%M:%OS", origin = "1970-01-01")
-    starttime_posix = as.POSIXlt(as.numeric(starttime_posix),
-                                 tz = desiredtz, origin = "1970-01-01")
   }
   
   # Correct timestamps


### PR DESCRIPTION
I was looking at timestamp handling in GGIR, so looked at GGIRread as well, and saw this minor issue. It doesn't really affect anything besides understandability of the code, but I thought I'd send a small PR anyway.

Basically I removed an unnecessary operation.

`starttime_posix` object [later gets converted with as.numeric()](https://github.com/wadpac/GGIRread/blob/8be2db62afa19bcd837392de7ad3cddccbe9ccff/R/readGENEActiv.R#L74), which produces a Unix timestamp, which is always in UTC.  So converting `starttime_posix` from `configtz` timezone to `desiredtz` doesn't achieve anything. The only thing that matters is that we use the correct timezone when converting from the original string representation to the POSIX object.

This extra operation wasn't breaking anything, but I think it's better to remove it so that there isn't any illusion from reading the code that the returned timestamps are somehow in `desiredtz`. They are unix timestamps, in UTC.