### PR TITLE
Extract GENEActiv starttime from first page header.

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,4 +4,3 @@
 prepareNewRelease.R
 LICENSE
 codecov.yml
-^.Rproj

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,3 +3,5 @@
 ^\.github
 prepareNewRelease.R
 LICENSE
+codecov.yml
+*.Rproj

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,4 +4,4 @@
 prepareNewRelease.R
 LICENSE
 codecov.yml
-*.Rproj
+^.Rproj

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+<!-- Describe your PR here -->
+
+<!-- Please, make sure the following items are checked -->
+Checklist before merging:
+
+- [ ] Existing tests still work (check by running the test suite, e.g. from RStudio).
+- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
+- [ ] Updated or expanded the documentation.
+- [ ] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
+- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.

--- a/.github/workflows/r_codecov.yml
+++ b/.github/workflows/r_codecov.yml
@@ -1,4 +1,4 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
@@ -23,8 +23,28 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: covr
+          extra-packages: any::covr
+          needs: coverage
 
       - name: Test coverage
-        run: covr::codecov()
+        run: |
+          covr::codecov(
+            quiet = FALSE,
+            clean = FALSE,
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
+          )
         shell: Rscript {0}
+
+      - name: Show testthat output
+        if: always()
+        run: |
+          ## --------------------------------------------------------------------
+          find ${{ runner.temp }}/package -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-test-failures
+          path: ${{ runner.temp }}/package

--- a/R/readGENEActiv.R
+++ b/R/readGENEActiv.R
@@ -31,6 +31,12 @@ readGENEActiv = function(filename, start = 0, end = 0, progress_bar = FALSE,
                      x = gsub(pattern = "Device Model:", replacement = "",
                         x = fh[grep(pattern = "Device Model", x = fh)[1]]))
   
+  if (starttime == "2010-09-16 09:10:00:000") {
+    # If recording started at this specific date and time then
+    # that indicates a known bug, use timestamp from first page instead
+    starttime = gsub(pattern = "Page Time:", replacement = "",
+                     x = fh[grep(pattern = "Page Time", x = fh)[1]])
+  }
   
   # Read acceleration, lux and temperature data
   rawdata = GENEActivReader(filename = filename,

--- a/R/readGENEActiv.R
+++ b/R/readGENEActiv.R
@@ -33,7 +33,9 @@ readGENEActiv = function(filename, start = 0, end = 0, progress_bar = FALSE,
   
   if (starttime == "2010-09-16 09:10:00:000") {
     # If recording started at this specific date and time then
-    # that indicates a known bug, use timestamp from first page instead
+    # that indicates a known incorrectness of the timestamp (based on 
+    # correspondence with manufacturer). In this case we should use the
+    # timestamp from first page instead.
     starttime = gsub(pattern = "Page Time:", replacement = "",
                      x = fh[grep(pattern = "Page Time", x = fh)[1]])
   }

--- a/R/readGENEActiv.R
+++ b/R/readGENEActiv.R
@@ -3,7 +3,7 @@ readGENEActiv = function(filename, start = 0, end = 0, progress_bar = FALSE,
   
   # Extract information from the fileheader
   suppressWarnings({fh = readLines(filename, 69)})
-  # fh = fh[1:30]
+  
   SN = gsub(pattern = "Device Unique Serial Code:", replacement = "",
             x = fh[grep(pattern = "Device Unique Serial Code", x = fh)[1]])
   firmware = gsub(pattern = "Device Firmware Version:", replacement = "",
@@ -12,8 +12,11 @@ readGENEActiv = function(filename, start = 0, end = 0, progress_bar = FALSE,
                   x = fh[grep(pattern = "Lux", x = fh)[1]]))
   Volts = as.numeric(gsub(pattern = "Volts:", replacement = "",
              x = fh[grep(pattern = "Volts", x = fh)[1]]))
-  starttime = gsub(pattern = "Start Time:", replacement = "",
-                  x = fh[grep(pattern = "Start Time", x = fh)[1]])
+  # We use first Page Time and not Start time from the file header
+  # because start time from the file header is known to be incorrect
+  # when battery runs out prior to end of recording
+  starttime = gsub(pattern = "Page Time:", replacement = "",
+                   x = fh[grep(pattern = "Page Time", x = fh)[1]])
   
   tzone = gsub(pattern = "Time Zone:", replacement = "",
                x = fh[grep(pattern = "Time Zone", x = fh)[1]])
@@ -30,16 +33,7 @@ readGENEActiv = function(filename, start = 0, end = 0, progress_bar = FALSE,
   DeviceModel = gsub(pattern = " ", replacement = "",
                      x = gsub(pattern = "Device Model:", replacement = "",
                         x = fh[grep(pattern = "Device Model", x = fh)[1]]))
-  
-  if (starttime == "2010-09-16 09:10:00:000") {
-    # If recording started at this specific date and time then
-    # that indicates a known incorrectness of the timestamp (based on 
-    # correspondence with manufacturer). In this case we should use the
-    # timestamp from first page instead.
-    starttime = gsub(pattern = "Page Time:", replacement = "",
-                     x = fh[grep(pattern = "Page Time", x = fh)[1]])
-  }
-  
+
   # Read acceleration, lux and temperature data
   rawdata = GENEActivReader(filename = filename,
                             start = start, end = end, 
@@ -77,7 +71,7 @@ readGENEActiv = function(filename, start = 0, end = 0, progress_bar = FALSE,
   
   # Correct timestamps
   page_offset = (((start - 1) * 300) / rawdata$info$SampleRate)
-  starttime_num = as.numeric(starttime_posix) + 5 + page_offset #tzone +
+  starttime_num = as.numeric(starttime_posix) + page_offset
   rawdata$time = rawdata$time + abs(rawdata$time[1]) + starttime_num
   return(invisible(list(
     header = header,

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -1,6 +1,11 @@
 \name{NEWS}
 \title{News for Package \pkg{GGIRread}}
 \newcommand{\cpkg}{\href{http://CRAN.R-project.org/package=#1}{\pkg{#1}}}
+\section{Changes in version 0.3.3 (GitHub-only-release date:23-01-2024)}{
+    \itemize{
+      \item When GENEActiv device battery runs low before downloading data the timestamp in the file header will default to 2010-9-16. This is now corrected by using the timestamp from the first page header instead, issue #56
+    }
+}
 \section{Changes in version 0.3.2 (GitHub-only-release date:05-12-2023)}{
     \itemize{
       \item Improved handling of failed checksum in .cwa files #53 (credits: Lena Kushleyeva)


### PR DESCRIPTION
This PR:

- Fixes #56. A client informed me that they corresponded with the manufacturer of GENEActiv and learnt that the start time reported in the file header becomes "2010-09-16 09:10:00:000" by default when recordings stops prematurely because of batteries running out (as described in #56). However, the timestamp in the first page header is always correct and I now use that as backup option if start time of file header matches this problematic date and time. Client has confirmed that this branch addresses the issue.
- Additionally, I am adding a PR template message which did not exist yet.
- Codecov yml edits to make it less strict about code coverage changes.