### PR TITLE
Issue #58 Don't print error when more data is requested from readGENEActiv() than is available in the file

### DIFF
--- a/src/GENEActivReader.cpp
+++ b/src/GENEActivReader.cpp
@@ -195,7 +195,7 @@ Rcpp::List GENEActivReader(std::string filename, std::size_t start = 0, std::siz
                         i++;
                     } catch (const std::exception& ex) {
                         errCounter++;
-                        Rcpp::Rcerr << "data error at i = %d: %s i: " << i << " " << ex.what() << "\n";
+                        Rcpp::Rcerr << "data error at i = " << i << " : " << ex.what() << "\n";
                         break;  // rest of this block could be corrupted
                     }
                 }

--- a/src/GENEActivReader.cpp
+++ b/src/GENEActivReader.cpp
@@ -195,7 +195,12 @@ Rcpp::List GENEActivReader(std::string filename, std::size_t start = 0, std::siz
                         i++;
                     } catch (const std::exception& ex) {
                         errCounter++;
-                        Rcpp::Rcerr << "data error at i = " << i << " : " << ex.what() << "\n";
+                        std::string err_text = ex.what();
+
+                        // report any error other than the one expected at the end of file
+                        if (err_text.find("stoll: no conversion") == std::string::npos) {
+                            Rcpp::Rcerr << "data error at i = " << i << " : " << err_text << "\n";
+                        }
                         break;  // rest of this block could be corrupted
                     }
                 }


### PR DESCRIPTION
<!-- Describe your PR here -->
Fixes https://github.com/wadpac/GGIRread/issues/58

Whenever `readGENEActiv()` got a request to read more data than what was left in the file, it used to print an error when the end of file was reached. The error was "data error at i = %d: %s i: <...> stoll: no conversion", in red; this made it look like something went wrong.

This PR removes this unnecessary error. Reaching the end of file in this scenario is normal behavior, and should not result in an error printed to `Rcerr`.

<!-- Please, make sure the following items are checked -->
Checklist before merging:

- [X] Existing tests still work (check by running the test suite, e.g. from RStudio).
- [ ] Added tests (if you added functionality) or fixed existing test (if you fixed a bug).
- [ ] Updated or expanded the documentation.
- [ ] Updated release notes in `inst/NEWS.Rd` with a user-readable summary. Please, include references to relevant issues or PR discussions.
- [ ] Added your name to the contributors lists in the `DESCRIPTION` file, if you think you made a significant contribution.
